### PR TITLE
Fixed minor typo in bayesass.py

### DIFF
--- a/bayesass.py
+++ b/bayesass.py
@@ -35,7 +35,7 @@ class Bayesass():
 			print(err)
 		except:
 			print("Unexpected error:")
-			print(sys.exec_info())
+			print(sys.exc_info())
 			raise SystemExit
 		return stdout
 		


### PR DESCRIPTION
print(sys.exec_info()) should be (print(sys.**exc_info()**) 

Error was hidden b/c that line doesn't get called unless the user causes the run_program to throw an exception (in my case, I specified the wrong number of loci)